### PR TITLE
Derive Eq for Full Equivalence Relations

### DIFF
--- a/src/purl.rs
+++ b/src/purl.rs
@@ -37,7 +37,7 @@ const ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b'|');
 
 /// A Package URL.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PackageUrl<'a> {
     /// The package URL type.


### PR DESCRIPTION
All of `PackageUrl`'s members implement `Eq` and `PackageUrl` itself already derives `PartialEq`. This adds an [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html) derive, which indicates symmetric and transitive equality, which `PackageUrl` has given all of its members do as well.